### PR TITLE
Fix role editing to single role

### DIFF
--- a/submission/static/submission/js/user_table.js
+++ b/submission/static/submission/js/user_table.js
@@ -25,7 +25,7 @@ new Vue({
             if (field === 'role') {
                 user.editingRole = true;
                 this.$nextTick(() => {
-                    $(`#roles-${user.id}`).select2().val(user.role.split(',')).trigger('change');
+                    $(`#roles-${user.id}`).select2().val(user.role).trigger('change');
                 });
             }
             if (field === 'group') {
@@ -36,18 +36,19 @@ new Vue({
             }
         },
         saveRole(user) {
-            const roles = $(`#roles-${user.id}`).val();
+            const role = $(`#roles-${user.id}`).val();
+            user.editingRole = false;
+            $(`#roles-${user.id}`).select2('destroy');
             fetch(`/users/update_role/${user.id}/`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
                     'X-CSRFToken': CSRF_TOKEN
                 },
-                body: JSON.stringify({ roles })
+                body: JSON.stringify({ role })
             }).then(res => {
                 if (res.ok) {
-                    user.role = roles.join(',');
-                    user.editingRole = false;
+                    user.role = role;
                 }
             });
         },

--- a/submission/templates/submission/user_list.html
+++ b/submission/templates/submission/user_list.html
@@ -88,7 +88,7 @@
                             <button class="ts-edit-btn" @click="enableEdit(user, 'role')">✏️</button>
                         </span>
                         <span v-else>
-                            <select :id="'roles-' + user.id" multiple style="width: 120px;">
+                            <select :id="'roles-' + user.id" style="width: 120px;">
                                 <option value="student">student</option>
                                 <option value="teacher">teacher</option>
                                 <option value="admin">admin</option>

--- a/submission/views_admin.py
+++ b/submission/views_admin.py
@@ -263,15 +263,14 @@ def update_user_role(request, user_id):
     if request.method == 'POST':
         try:
             data = json.loads(request.body)
-            new_roles = data.get('roles')
+            new_role = data.get('role')
 
             user = User.objects.get(id=user_id)
             profile = user.userprofile
 
-            # ロール設定の例（複数ロールを許可する場合）
-            profile.role = ','.join(new_roles)
-            user.is_superuser = 'admin' in new_roles
-            user.is_staff = 'teacher' in new_roles or 'admin' in new_roles
+            profile.role = new_role
+            user.is_superuser = new_role == 'admin'
+            user.is_staff = new_role in ['teacher', 'admin']
 
             profile.save()
             user.save()


### PR DESCRIPTION
## Summary
- make role dropdown single-select
- hide select after saving
- adapt JS logic to send single role
- adjust backend update to expect single role

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684296909de0832cb6af63ab92a41df5