### PR TITLE
Fix scoring summary and preserve PDF annotations

### DIFF
--- a/submission/static/submission/js/grading_form.js
+++ b/submission/static/submission/js/grading_form.js
@@ -78,7 +78,6 @@ new Vue({
             if (this.tool === 'stamp') return;
             if (!this.isDrawable()) return;
             this.drawing = false;
-            this.currentPage = null;
             this.undoStack[idx] = [];
         },
         redraw(idx) {
@@ -211,7 +210,11 @@ new Vue({
                     key: lab.label
                   }));
             }
-            // console.table(this.scoreItems)
+            const saved = window.initialScoreDetails || [];
+            this.scoreItems.forEach(item => {
+                const found = saved.find(s => s.label === item.label);
+                if (found) item.value = found.value || 0;
+            });
           });
         // PDF.js lazy load
         const url = window.pdf_url;

--- a/submission/static/submission/js/user_profile.js
+++ b/submission/static/submission/js/user_profile.js
@@ -3,6 +3,7 @@ new Vue({
     data: {
       userProfile: {},
       submissions: [],
+      scoreSummary: [],
       showPwChange: false,
       password1: "",
       password2: "",
@@ -16,6 +17,7 @@ new Vue({
             this.userProfile = data.profile;
             if (data.profile.role === "student") {
               this.submissions = data.submissions || [];
+              this.scoreSummary = data.score_summary || [];
             }
           });
       },

--- a/submission/templates/submission/grading_form.html
+++ b/submission/templates/submission/grading_form.html
@@ -96,6 +96,7 @@
     window.csrfToken = '{{ csrf_token }}';
     window.reportType = "{{ submission.report_type }}";
     window.userRole = "{{ request.user.userprofile.role }}";
+    window.initialScoreDetails = {{ score_details|safe }};
 </script>
 
 <script src="https://cdn.jsdelivr.net/npm/vue@2"></script>

--- a/submission/templates/submission/user_profile.html
+++ b/submission/templates/submission/user_profile.html
@@ -46,6 +46,13 @@
             </li>
         </ul>
         <div v-if="submissions.length === 0">提出レポートなし</div>
+
+        <h4 class="mt-4">実験別合計得点</h4>
+        <ul>
+            <li v-for="sum in scoreSummary">
+                {{ sum.experiment_number }}: {{ sum.total_score }}
+            </li>
+        </ul>
     </div>
     {% endverbatim %}
 </div>

--- a/submission/views_grading.py
+++ b/submission/views_grading.py
@@ -27,24 +27,12 @@ def grading_form(request, submission_id):
         # PyMuPDFでPDF編集
         doc = fitz.open(pdf_path)
         for page_no, img_data in enumerate(images):
+            if not img_data:
+                continue
             page = doc[page_no]
-            # 元ページを画像でレンダリング
-            pix = page.get_pixmap(dpi=200)
-            pdf_image = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
-            # 手書きがある場合だけ合成
-            if img_data:
-                header, encoded = img_data.split(",", 1)
-                hand_img_bytes = base64.b64decode(encoded)
-                hand_image = Image.open(io.BytesIO(hand_img_bytes)).convert("RGBA")
-                # 手書き画像を元ページに合成
-                pdf_image = pdf_image.convert("RGBA")
-                pdf_image.alpha_composite(hand_image.resize(pdf_image.size))
-            # 新しい画像をPDFページに貼り直す
-            out_io = io.BytesIO()
-            pdf_image.convert("RGB").save(out_io, format="PNG")
-            out_io.seek(0)
-            page.clean_contents()  # 既存の内容を消す
-            page.insert_image(page.rect, stream=out_io.read())
+            header, encoded = img_data.split(",", 1)
+            hand_img_bytes = base64.b64decode(encoded)
+            page.insert_image(page.rect, stream=hand_img_bytes, overlay=True)
 
         # 保存名（例: sample_graded.pdf）
         base, ext = os.path.splitext(os.path.basename(pdf_path))
@@ -66,7 +54,12 @@ def grading_form(request, submission_id):
         return JsonResponse({'status': 'ok', 'new_file_url': submission.file.url})
 
     # GET時
-    return render(request, 'submission/grading_form.html', {'submission': submission, 'pdf_url': submission.file.url})
+    score_json = json.dumps(submission.score_details) if submission.score_details else 'null'
+    return render(request, 'submission/grading_form.html', {
+        'submission': submission,
+        'pdf_url': submission.file.url,
+        'score_details': score_json,
+    })
 
 @login_required
 def scoring_items_api(request):


### PR DESCRIPTION
## Summary
- add experiment score summary to student profile API
- display score totals per experiment on the profile page
- restore score details when reopening grading form
- keep last edited page for undo/redo shortcuts
- preserve the original PDF when saving annotations

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6842b36224ac832c9c309b5e8e0bbbed