### PR TITLE
Add email field and fix footer logout

### DIFF
--- a/submission/forms.py
+++ b/submission/forms.py
@@ -33,12 +33,12 @@ class SignUpForm(forms.ModelForm):
         model = User
         fields = ("username", "password")
 
-    def clean_email(self):
-        email = self.cleaned_data.get('email')
+    def clean_username(self):
+        username = self.cleaned_data.get('username')
         allowed_domain = 'g.nihon-u.ac.jp'  # ← 必要に応じて変更
-        if not email.endswith(f'@{allowed_domain}'):
+        if not username.endswith(f'@{allowed_domain}'):
             raise ValidationError(f'{allowed_domain} ドメインのメールアドレスのみ使用できます。')
-        return email
+        return username
 
     def clean(self):
         cleaned_data = super().clean()

--- a/submission/migrations/0014_userprofile_email.py
+++ b/submission/migrations/0014_userprofile_email.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('submission', '0013_stamp'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='email',
+            field=models.EmailField(default='', max_length=254),
+            preserve_default=False,
+        ),
+    ]

--- a/submission/models.py
+++ b/submission/models.py
@@ -49,6 +49,7 @@ class UserProfile(models.Model):
         ('火', '火'), ('木', '木')
     ])
     experiment_group = models.CharField(max_length=2)
+    email = models.EmailField()
     role = models.CharField(max_length=10, choices=ROLE_CHOICES, default='student')
 
     def __str__(self):

--- a/submission/templates/submission/footer.html
+++ b/submission/templates/submission/footer.html
@@ -2,7 +2,10 @@
     <div class="footer-content">
         <div class="footer-login">
             あなたは <span class="footer-user">{{ request.user.username }} {{ request.user.get_full_name }}</span> としてログインしています 
-            (<a href="{% url 'logout' %}" class="footer-logout">ログアウト</a>)
+            (<form method="post" action="{% url 'logout' %}" style="display:inline;">
+                {% csrf_token %}
+                <button type="submit" class="footer-logout" style="background:none;border:none;padding:0;">ログアウト</button>
+            </form>)
         </div>
         <a href="{% url 'index_redirect' %}" class="footer-home">Home</a>
     </div>

--- a/submission/views.py
+++ b/submission/views.py
@@ -23,7 +23,10 @@ def signup_view(request):
     if request.method == 'POST':
         form = SignUpForm(request.POST)
         if form.is_valid():
+            username = form.cleaned_data["username"]
             user = form.save(commit=False)
+            user.username = username
+            user.email = username
             user.set_password(form.cleaned_data["password"])
             user.save()
             profile = UserProfile.objects.create(
@@ -33,6 +36,7 @@ def signup_view(request):
                 experiment_day=form.cleaned_data['experiment_day'],
                 experiment_group=form.cleaned_data['experiment_group'],
                 role='student',  # ← 明示的に初期ロールを設定
+                email=username,
             )
             login(request, user)
             messages.success(request, 'ユーザー登録が完了しました')
@@ -62,7 +66,7 @@ def api_user_profile(request):
     user_data = {
         "full_name": profile.full_name,
         "student_id": profile.student_id,
-        "email": request.user.email,
+        "email": profile.email,
         "experiment_day": profile.experiment_day,
         "experiment_group": profile.experiment_group,
         "role": profile.role,

--- a/submission/views_admin.py
+++ b/submission/views_admin.py
@@ -336,6 +336,7 @@ def create_user_view(request):
             profile = UserProfile.objects.create(
                 user=user,
                 full_name=data['full_name'],
+                email=data['email'],
                 student_id=data['student_id'],
                 experiment_day=data['experiment_day'],
                 experiment_group=data['experiment_group'],


### PR DESCRIPTION
## Summary
- enforce allowed domain for username on signup
- store signup email on `UserProfile`
- expose email in profile API
- include email when admins create users
- fix logout link in footer so it uses POST

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68466fcb1718832cbbb8af4ab96efa4d