### PR TITLE
Add student ID sorting and filters on user page

### DIFF
--- a/submission/static/submission/js/admin_dashboard.js
+++ b/submission/static/submission/js/admin_dashboard.js
@@ -15,7 +15,7 @@ window.app = new Vue({
         summaryLoaded: false,
         showAddModal: false,
         showEditModal: false,
-        filter: { experiment_day: '', experiment_group: '', experiment_number: '' },
+        filter: { experiment_day: '', experiment_group: '', experiment_number: '', student_id: '' },
         form: {
             id: null,
             date: '',
@@ -83,7 +83,11 @@ window.app = new Vue({
                 });
         },
         fetchStudens() {
-            fetch('/submission/admin_students_api/')
+            const params = [];
+            if (this.filter.student_id) params.push('student_id=' + encodeURIComponent(this.filter.student_id));
+            let url = '/submission/admin_students_api/';
+            if (params.length) url += '?' + params.join('&');
+            fetch(url)
                 .then(r => r.json())
                 .then(data => {
                     console.log(data.students_json);
@@ -92,7 +96,11 @@ window.app = new Vue({
                 });
         },
         fetchSummary() {
-            fetch('/submission/admin_summary_api/')
+            const params = [];
+            if (this.filter.student_id) params.push('student_id=' + encodeURIComponent(this.filter.student_id));
+            let url = '/submission/admin_summary_api/';
+            if (params.length) url += '?' + params.join('&');
+            fetch(url)
                 .then(r => r.json())
                 .then(data => {
                     this.submissionSummary = data.submission_summary;

--- a/submission/static/submission/js/user_table.js
+++ b/submission/static/submission/js/user_table.js
@@ -10,6 +10,9 @@ new Vue({
             Array.from({ length: 20 }, (_, i) => day + '-' + ('0' + (i + 1)).slice(-2))
         )),
         showModal: false,
+        filters: { role: '', group: '' },
+        sortField: '',
+        sortAsc: true,
         newUser: {
             full_name: '',
             email: '',
@@ -20,7 +23,30 @@ new Vue({
             experiment_group: '01'
         }
     },
+    computed: {
+        processedUsers() {
+            let list = this.users.slice();
+            if (this.filters.role) list = list.filter(u => u.role === this.filters.role);
+            if (this.filters.group) list = list.filter(u => u.group === this.filters.group);
+            if (this.sortField === 'student_id') {
+                list.sort((a,b) => {
+                    const av = a.student_id || '';
+                    const bv = b.student_id || '';
+                    return this.sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
+                });
+            }
+            return list;
+        }
+    },
     methods: {
+        toggleSort(field) {
+            if (this.sortField === field) {
+                this.sortAsc = !this.sortAsc;
+            } else {
+                this.sortField = field;
+                this.sortAsc = true;
+            }
+        },
         enableEdit(user, field) {
             if (field === 'role') {
                 user.editingRole = true;

--- a/submission/templates/submission/admin_dashboard.html
+++ b/submission/templates/submission/admin_dashboard.html
@@ -29,7 +29,7 @@
         </li>
     </ul>
 
-    <div class="row mb-2">
+    <div class="row mb-2" v-if="tab === 'submissions'">
         <div class="col-auto">
             <select class="form-select" v-model="filter.experiment_day">
                 <option value="">曜日</option>
@@ -62,6 +62,15 @@
         </div>
         <div class="col-auto">
             <button class="btn btn-outline-primary" @click="fetchList()">検索</button>
+        </div>
+    </div>
+
+    <div class="row mb-2" v-if="tab === 'summary' || tab === 'student'">
+        <div class="col-auto">
+            <input type="text" class="form-control" v-model="filter.student_id" placeholder="学籍番号">
+        </div>
+        <div class="col-auto">
+            <button class="btn btn-outline-primary" @click="tab === 'summary' ? fetchSummary() : fetchStudens()">検索</button>
         </div>
     </div>
 

--- a/submission/templates/submission/user_list.html
+++ b/submission/templates/submission/user_list.html
@@ -70,17 +70,35 @@
                 <tr>
                     <th>名前</th>
                     <th>メールアドレス</th>
-                    <th>ロール</th>
-                    <th>グループ</th>
+                    <th @click="toggleSort('student_id')" style="cursor:pointer">学生番号</th>
+                    <th>ロール
+                        <div>
+                            <select v-model="filters.role" class="form-select form-select-sm">
+                                <option value="">全て</option>
+                                <option value="student">student</option>
+                                <option value="teacher">teacher</option>
+                                <option value="admin">admin</option>
+                            </select>
+                        </div>
+                    </th>
+                    <th>グループ
+                        <div>
+                            <select v-model="filters.group" class="form-select form-select-sm">
+                                <option value="">全て</option>
+                                <option v-for="option in groupOptions" :value="option" v-text="option"></option>
+                            </select>
+                        </div>
+                    </th>
                     <th>最終アクセス</th>
                     <th>操作</th>
                 </tr>
             </thead>
             <tbody>
             {% verbatim %}
-                <tr v-for="user in users" :key="user.id">
+                <tr v-for="user in processedUsers" :key="user.id">
                     <td>{{ user.name }}</td>
                     <td>{{ user.email }}</td>
+                    <td>{{ user.student_id }}</td>
                     <!-- ロール編集 -->
                     <td>
                         <span v-if="!user.editingRole">

--- a/submission/views_admin.py
+++ b/submission/views_admin.py
@@ -70,16 +70,24 @@ def admin_get_submissions_api(request):
     return JsonResponse({'submissions': submissions})
 
 def get_students_api(request):
+    student_id = request.GET.get('student_id')
+    qs = UserProfile.objects.filter(role='student')
+    if student_id:
+        qs = qs.filter(student_id__icontains=student_id)
     students = list(
-        UserProfile.objects.filter(role='student').values(
-            'id', 'full_name', 'student_id', 'user__email', 'experiment_day', 'experiment_group'
+        qs.values(
+            'id', 'full_name', 'student_id', 'user__email',
+            'experiment_day', 'experiment_group'
         )
     )
     return JsonResponse({'students_json': students})
 
 def get_summary_api(request):
     experiment_numbers = [x[0] for x in Submission.EXPERIMENT_NUMBER_CHOICES]
+    student_id = request.GET.get('student_id')
     students = UserProfile.objects.filter(role='student')
+    if student_id:
+        students = students.filter(student_id__icontains=student_id)
     results = []
     for item in students:
         user = item.user
@@ -254,6 +262,7 @@ def user_list_view(request):
                 'id': user.id,
                 'name': profile.full_name,
                 'email': user.email,
+                'student_id': profile.student_id,
                 'role': role,
                 'group': group,
                 'last_login': last_login


### PR DESCRIPTION
## Summary
- include `student_id` in user list API
- add sort/filter UI for student ID, role, and group on the admin user table

## Testing
- `python manage.py check` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684696e75150832cade695051f88804a