### PR TITLE
Enhance grading UI with highlight and undo/redo buttons

### DIFF
--- a/submission/static/submission/js/grading_form.js
+++ b/submission/static/submission/js/grading_form.js
@@ -14,6 +14,8 @@ new Vue({
         undoStack: [],
         stamps: [],
         selectedStamp: "",
+        penWidth: 2,
+        highlightWidth: 10,
     },
     computed: {
         totalScore() {
@@ -27,7 +29,7 @@ new Vue({
         inc(item) { item.value++; },
         dec(item) { if (item.value > 0) item.value--; },
         isPenActive() { return this.tool === 'pen'; },
-        isDrawable() { return this.tool === 'pen' || this.tool === 'eraser'; },
+        isDrawable() { return this.tool === 'pen' || this.tool === 'eraser' || this.tool === 'highlight'; },
         startDraw(idx, e) {
             if (this.tool === 'stamp') {
                 const rect = e.target.getBoundingClientRect();
@@ -47,7 +49,9 @@ new Vue({
             this.lastY = e.clientY - rect.top;
             if (!this.drawData[idx]) this.drawData[idx] = [];
             if (!this.undoStack[idx]) this.undoStack[idx] = [];
-            this.drawData[idx].push({ tool: this.tool, points: [{ x: this.lastX, y: this.lastY }] });
+            let width = this.penWidth;
+            if (this.tool === 'highlight') width = this.highlightWidth;
+            this.drawData[idx].push({ tool: this.tool, width: width, points: [{ x: this.lastX, y: this.lastY }] });
         },
         draw(idx, e) {
             if (this.tool === 'stamp') return;
@@ -60,10 +64,14 @@ new Vue({
             if (this.tool === 'eraser') {
                 ctx.globalCompositeOperation = 'destination-out';
                 ctx.lineWidth = 30;
+            } else if (this.tool === 'highlight') {
+                ctx.globalCompositeOperation = 'source-over';
+                ctx.strokeStyle = 'rgba(255,255,0,0.4)';
+                ctx.lineWidth = this.highlightWidth;
             } else {
                 ctx.globalCompositeOperation = 'source-over';
                 ctx.strokeStyle = "red";
-                ctx.lineWidth = 2;
+                ctx.lineWidth = this.penWidth;
             }
             ctx.lineCap = "round";
             ctx.beginPath();
@@ -102,10 +110,14 @@ new Vue({
                 if (stroke.tool === 'eraser') {
                     ctx.globalCompositeOperation = 'destination-out';
                     ctx.lineWidth = 10;
+                } else if (stroke.tool === 'highlight') {
+                    ctx.globalCompositeOperation = 'source-over';
+                    ctx.strokeStyle = 'rgba(255,255,0,0.4)';
+                    ctx.lineWidth = stroke.width || this.highlightWidth;
                 } else {
                     ctx.globalCompositeOperation = 'source-over';
                     ctx.strokeStyle = "red";
-                    ctx.lineWidth = 2;
+                    ctx.lineWidth = stroke.width || this.penWidth;
                 }
                 ctx.beginPath();
                 for (let i = 0; i < stroke.points.length; i++) {

--- a/submission/templates/submission/grading_form.html
+++ b/submission/templates/submission/grading_form.html
@@ -20,6 +20,8 @@
             <div class="pdf-toolbar mb-2">
                 <button class="btn btn-outline-secondary" :class="{active: tool==='pen'}"
                     @click="tool='pen'">ペン</button>
+                <button class="btn btn-outline-secondary" :class="{active: tool==='highlight'}"
+                    @click="tool='highlight'">蛍光ペン</button>
                 <button class="btn btn-outline-secondary" :class="{active: tool==='eraser'}"
                     @click="tool='eraser'">消しゴム</button>
                 <button class="btn btn-outline-secondary" :class="{active: tool==='stamp'}"
@@ -29,6 +31,10 @@
                     <option v-for="s in stamps" :key="s.id" :value="s.text">{{ s.text }}</option>
                     {% endverbatim %}
                 </select>
+                <input v-if="tool==='pen'" type="range" min="1" max="10" v-model.number="penWidth" class="form-range d-inline-block ms-2" style="width:100px;">
+                <input v-if="tool==='highlight'" type="range" min="5" max="30" v-model.number="highlightWidth" class="form-range d-inline-block ms-2" style="width:100px;">
+                <button class="btn btn-outline-secondary ms-2" @click="undo(currentPage != null ? currentPage : 0)">戻る</button>
+                <button class="btn btn-outline-secondary ms-2" @click="redo(currentPage != null ? currentPage : 0)">進む</button>
             </div>
             <div id="pdf-area" style="position:relative;width:100%;background:#eee;overflow-y:auto;max-height:80vh;">
                 <div id="pdf-pages">


### PR DESCRIPTION
## Summary
- add highlighter tool and width controls
- add undo/redo buttons next to stamp selector
- support variable stroke width for pen and highlighter

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848f9ef61d0832cb1bb005ed7965579