### PR TITLE
Add bulk CSV user import

### DIFF
--- a/submission/static/submission/js/user_table.js
+++ b/submission/static/submission/js/user_table.js
@@ -158,6 +158,34 @@ new Vue({
             .catch(err => {
                 console.error("通信エラー", err);
             });
+        },
+        triggerFileInput() {
+            this.$refs.csvInput.click();
+        },
+        uploadCsv(event) {
+            const file = event.target.files[0];
+            if (!file) return;
+            const formData = new FormData();
+            formData.append('file', file);
+            fetch('/users/bulk_create/', {
+                method: 'POST',
+                headers: {
+                    'X-CSRFToken': CSRF_TOKEN,
+                },
+                body: formData,
+            })
+            .then(res => res.json())
+            .then(data => {
+                if (data.status === 'success') {
+                    alert('登録が完了しました');
+                    location.reload();
+                } else {
+                    alert('登録失敗: ' + data.message);
+                }
+            })
+            .catch(err => {
+                console.error('通信エラー', err);
+            });
         }
     }
 });

--- a/submission/templates/submission/user_list.html
+++ b/submission/templates/submission/user_list.html
@@ -12,6 +12,8 @@
 <div id="user-table" class="p-4">
     <h2>ユーザ一覧</h2>
     <button class="btn btn-primary mb-3" @click="showModal = true">＋ 新規ユーザー登録</button>
+    <button class="btn btn-secondary mb-3" @click="triggerFileInput">ユーザ一括登録</button>
+    <input type="file" ref="csvInput" accept=".csv" @change="uploadCsv" style="display:none">
 
     <!-- 新規ユーザー登録モーダル -->
     {% verbatim %}

--- a/submission/urls.py
+++ b/submission/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('update_group/<int:user_id>/', views_admin.update_group_view, name='update_group'),
     path('delete/<int:user_id>/', views_admin.delete_user_view, name='delete_user'),
     path('create/', views_admin.create_user_view, name='create_user'),
+    path('bulk_create/', views_admin.bulk_create_users, name='bulk_create_users'),
     
     path('admin_dashboard/', views_admin.admin_dashboard, name='admin_dashboard'),
     path('admin_submissions_api/', views_admin.admin_get_submissions_api, name='admin_get_submissions_api'),


### PR DESCRIPTION
## Summary
- allow admins to upload CSV to create multiple users
- hook the new backend into user list page
- add frontend controls to upload CSV

## Testing
- `python manage.py test` *(fails: couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_68490d360860832c8936600518062aae