### PR TITLE
Add attendance improvements

### DIFF
--- a/attendance/static/attendance/css/attendance_list.css
+++ b/attendance/static/attendance/css/attendance_list.css
@@ -1,0 +1,37 @@
+.ts-attendance-wrapper {
+    max-width: 1000px;
+    margin: 40px auto;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(60,60,90,0.09);
+    padding: 28px 32px 38px 32px;
+}
+.ts-table-container { width: 100%; overflow-x: auto; }
+.ts-table {
+    width: 100%;
+    background: #fff;
+    border-collapse: separate;
+    border-spacing: 0;
+    box-shadow: 0 2px 12px rgba(90,80,120,0.05);
+    font-size: 1rem;
+}
+.ts-table th, .ts-table td {
+    padding: 0.7em 1.2em;
+    text-align: left;
+    vertical-align: middle;
+    border-bottom: 1px solid #eaeaea;
+}
+.ts-table th {
+    background: #f7f6fb;
+    font-weight: bold;
+    color: #3c2669;
+}
+
+.ts-attendance-columns {
+    display: flex;
+    gap: 2%;
+}
+
+.ts-column {
+    flex: 1;
+}

--- a/attendance/templates/attendance/attendance_list.html
+++ b/attendance/templates/attendance/attendance_list.html
@@ -1,30 +1,72 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <title>Attendance List</title>
-</head>
-<body>
-<h1>Today's Attendance</h1>
-<table border="1">
-    <tr>
-        <th>Student ID</th>
-        <th>Name</th>
-        <th>Day</th>
-        <th>Group</th>
-        <th>Check In</th>
-        <th>Check Out</th>
-    </tr>
-    {% for record in records %}
-    <tr>
-        <td>{{ record.user.userprofile.student_id }}</td>
-        <td>{{ record.user.userprofile.full_name }}</td>
-        <td>{{ record.user.userprofile.experiment_day }}</td>
-        <td>{{ record.user.userprofile.experiment_group }}</td>
-        <td>{{ record.check_in }}</td>
-        <td>{{ record.check_out }}</td>
-    </tr>
-    {% endfor %}
-</table>
-</body>
-</html>
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}出席一覧{% endblock %}
+
+{% block extra_css %}
+<link rel="stylesheet" href="{% static 'attendance/css/attendance_list.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="ts-attendance-wrapper">
+    <h2>本日の出席記録</h2>
+    <div class="ts-attendance-columns">
+        <div class="ts-column">
+            <h3>入室中</h3>
+            <div class="ts-table-container">
+                <table class="ts-table">
+                    <thead>
+                        <tr>
+                            <th>学籍番号</th>
+                            <th>氏名</th>
+                            <th>曜日</th>
+                            <th>班</th>
+                            <th>入室</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for record in in_records %}
+                        <tr>
+                            <td>{{ record.user.userprofile.student_id }}</td>
+                            <td>{{ record.user.userprofile.full_name }}</td>
+                            <td>{{ record.user.userprofile.experiment_day }}</td>
+                            <td>{{ record.user.userprofile.experiment_group }}</td>
+                            <td>{{ record.check_in|date:'H:i' }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="ts-column">
+            <h3>退室済み</h3>
+            <div class="ts-table-container">
+                <table class="ts-table">
+                    <thead>
+                        <tr>
+                            <th>学籍番号</th>
+                            <th>氏名</th>
+                            <th>曜日</th>
+                            <th>班</th>
+                            <th>入室</th>
+                            <th>退室</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    {% for record in out_records %}
+                        <tr>
+                            <td>{{ record.user.userprofile.student_id }}</td>
+                            <td>{{ record.user.userprofile.full_name }}</td>
+                            <td>{{ record.user.userprofile.experiment_day }}</td>
+                            <td>{{ record.user.userprofile.experiment_group }}</td>
+                            <td>{{ record.check_in|date:'H:i' }}</td>
+                            <td>{{ record.check_out|date:'H:i' }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/submission/static/submission/js/user_table.js
+++ b/submission/static/submission/js/user_table.js
@@ -4,7 +4,8 @@ new Vue({
         users: USERS_DATA.map(user => ({
             ...user,
             editingRole: false,
-            editingGroup: false
+            editingGroup: false,
+            can_view_attendance: user.can_view_attendance
         })),
         groupOptions: [].concat(...['火', '木'].map(day =>
             Array.from({ length: 20 }, (_, i) => day + '-' + ('0' + (i + 1)).slice(-2))
@@ -104,6 +105,20 @@ new Vue({
                 user.editingGroup = false;
                 $(`#groups-${user.id}`).select2('destroy');
             }
+        },
+        toggleAttendance(user) {
+            fetch(`/users/update_permission/${user.id}/`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': CSRF_TOKEN
+                },
+                body: JSON.stringify({ allow: user.can_view_attendance })
+            }).then(res => {
+                if (!res.ok) {
+                    user.can_view_attendance = !user.can_view_attendance;
+                }
+            });
         },
         deleteUser(user) {
             if (!confirm(`${user.name} を本当に削除しますか？`)) return;

--- a/submission/templates/submission/user_list.html
+++ b/submission/templates/submission/user_list.html
@@ -91,6 +91,7 @@
                             </select>
                         </div>
                     </th>
+                    <th>出席閲覧</th>
                     <th>最終アクセス</th>
                     <th>操作</th>
                 </tr>
@@ -130,6 +131,9 @@
                             <button class="ts-save-btn" @click="saveGroup(user)">💾</button>
                             <button class="ts-cancel-edit-btn" @click="cancelEdit(user, 'group')">✕</button>
                         </span>
+                    </td>
+                    <td>
+                        <input type="checkbox" v-model="user.can_view_attendance" @change="toggleAttendance(user)">
                     </td>
                     <td>{{ user.last_login }}</td>
                     <td>

--- a/submission/urls.py
+++ b/submission/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('list/', views_admin.user_list_view, name='user_list'),
     path('update_role/<int:user_id>/', views_admin.update_user_role, name='update_role'),
     path('update_group/<int:user_id>/', views_admin.update_group_view, name='update_group'),
+    path('update_permission/<int:user_id>/', views_admin.update_attendance_permission, name='update_attendance_permission'),
     path('delete/<int:user_id>/', views_admin.delete_user_view, name='delete_user'),
     path('create/', views_admin.create_user_view, name='create_user'),
     path('bulk_create/', views_admin.bulk_create_users, name='bulk_create_users'),


### PR DESCRIPTION
## Summary
- modernize attendance list layout separating in-room and checked-out
- finalize previous day records automatically at midnight
- cap early checkout penalty and integrate with score system

## Testing
- `venv/bin/python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68492f75fcc4832cace55cd2f26914e8