### PR TITLE
Add Vue-based NFC register script

### DIFF
--- a/attendance/static/attendance/js/nfc_register.js
+++ b/attendance/static/attendance/js/nfc_register.js
@@ -1,0 +1,62 @@
+document.addEventListener('DOMContentLoaded', function () {
+    new Vue({
+        el: '#nfc-app',
+        data: {
+            showModal: false,
+            students: window.STUDENTS || [],
+            selectedId: '',
+            nfcId: ''
+        },
+        computed: {
+            selectedUser() {
+                return this.students.find(s => s.student_id === this.selectedId) || {};
+            }
+        },
+        methods: {
+            open() {
+                this.showModal = true;
+                this.nfcId = '';
+                this.$nextTick(() => {
+                    if (this.$refs.nfcInput) this.$refs.nfcInput.focus();
+                });
+            },
+            close() {
+                this.showModal = false;
+            },
+            registerNfc() {
+                const sid = this.selectedId;
+                const nfc = this.nfcId.trim();
+                if (!sid || !nfc) {
+                    alert('学生とNFCを入力してください');
+                    return;
+                }
+                fetch('/attendance/register_nfc/', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRFToken': CSRF_TOKEN
+                    },
+                    body: JSON.stringify({ student_id: sid, nfc_id: nfc })
+                })
+                    .then(r => r.json())
+                    .then(d => {
+                        if (d.status === 'success') {
+                            const st = this.students.find(s => s.student_id === sid);
+                            if (st) st.nfc_id = nfc;
+                            alert('登録しました');
+                        } else {
+                            alert(d.message || 'エラー');
+                        }
+                    })
+                    .catch(() => alert('通信エラー'));
+            }
+        },
+        watch: {
+            selectedId() {
+                this.$nextTick(() => {
+                    if (this.$refs.nfcInput) this.$refs.nfcInput.focus();
+                });
+            }
+        }
+    });
+});

--- a/attendance/templates/attendance/attendance_list.html
+++ b/attendance/templates/attendance/attendance_list.html
@@ -5,11 +5,45 @@
 
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'attendance/css/attendance_list.css' %}">
+<link rel="stylesheet" href="{% static 'submission/css/user_table.css' %}">
 {% endblock %}
 
 {% block content %}
 <div class="ts-attendance-wrapper">
     <h2>本日の出席記録</h2>
+    {% verbatim %}
+    <div id="nfc-app">
+        <button class="btn btn-primary mb-3" @click="open">NFC登録</button>
+        <div v-if="showModal" class="ts-modal-overlay">
+            <div class="ts-modal">
+                <h3>NFC登録</h3>
+                <div class="ts-form-group">
+                    <label>学生番号</label>
+                    <select v-model="selectedId">
+                        <option value="">選択してください</option>
+                        <option v-for="s in students" :value="s.student_id">
+                            {{ s.student_id }} {{ s.full_name }}
+                        </option>
+                    </select>
+                </div>
+                <div class="ts-form-group">
+                    <p>氏名: <span v-text="selectedUser.full_name"></span></p>
+                    <p>曜日: <span v-text="selectedUser.experiment_day"></span></p>
+                    <p>班: <span v-text="selectedUser.experiment_group"></span></p>
+                    <p>NFC: <span v-text="selectedUser.nfc_id"></span></p>
+                </div>
+                <div class="ts-form-group">
+                    <label>NFC ID</label>
+                    <input type="text" v-model="nfcId" ref="nfcInput">
+                </div>
+                <div class="ts-modal-actions">
+                    <button class="ts-create-btn" @click="registerNfc">登録</button>
+                    <button class="ts-cancel-btn" @click="close">キャンセル</button>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endverbatim %}
     <div class="ts-attendance-columns">
         <div class="ts-column">
             <h3>入室中</h3>
@@ -69,4 +103,12 @@
         </div>
     </div>
 </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    var STUDENTS = {{ students_json|safe }};
+    var CSRF_TOKEN = '{{ csrf_token }}';
+</script>
+<script src="{% static 'attendance/js/nfc_register.js' %}"></script>
 {% endblock %}

--- a/attendance/urls.py
+++ b/attendance/urls.py
@@ -4,4 +4,6 @@ from . import views
 urlpatterns = [
     path('scan/<str:student_id>/', views.scan_card, name='scan_card'),
     path('list/', views.attendance_list, name='attendance_list'),
+    path('user_info/<str:student_id>/', views.get_user_info, name='attendance_user_info'),
+    path('register_nfc/', views.register_nfc, name='register_nfc'),
 ]

--- a/submission/migrations/0017_userprofile_nfc_id.py
+++ b/submission/migrations/0017_userprofile_nfc_id.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('submission', '0016_alter_schedule_teacher'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='nfc_id',
+            field=models.CharField(max_length=50, null=True, blank=True),
+        ),
+    ]

--- a/submission/models.py
+++ b/submission/models.py
@@ -49,6 +49,7 @@ class UserProfile(models.Model):
         ('火', '火'), ('木', '木')
     ])
     experiment_group = models.CharField(max_length=2)
+    nfc_id = models.CharField(max_length=50, null=True, blank=True)
     email = models.EmailField(max_length=255, null=True, blank=True)
     role = models.CharField(max_length=10, choices=ROLE_CHOICES, default='student')
 

--- a/submission/templates/base.html
+++ b/submission/templates/base.html
@@ -24,5 +24,6 @@
         var USER_ROLE = "{{ request.user.userprofile.role }}";
     </script>
     <script src="{% static 'submission/js/header.js' %}"></script>
+    {% block extra_js %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor NFC registration to use Vue-based script
- rename script to `nfc_register.js`
- embed NFC registration modal markup with Vue directives

## Testing
- `python -m py_compile attendance/views.py submission/models.py submission/migrations/0017_userprofile_nfc_id.py attendance/urls.py`


------
https://chatgpt.com/codex/tasks/task_e_684938acad3c832c83c54855cdead1cf