### PR TITLE
Implement student photo capture

### DIFF
--- a/submission/migrations/0018_userprofile_photo.py
+++ b/submission/migrations/0018_userprofile_photo.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('submission', '0017_userprofile_nfc_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userprofile',
+            name='photo',
+            field=models.ImageField(upload_to='student_photos/', null=True, blank=True),
+        ),
+    ]

--- a/submission/models.py
+++ b/submission/models.py
@@ -51,6 +51,7 @@ class UserProfile(models.Model):
     experiment_group = models.CharField(max_length=2)
     nfc_id = models.CharField(max_length=50, null=True, blank=True)
     email = models.EmailField(max_length=255, null=True, blank=True)
+    photo = models.ImageField(upload_to='student_photos/', null=True, blank=True)
     role = models.CharField(max_length=10, choices=ROLE_CHOICES, default='student')
 
     def __str__(self):

--- a/submission/static/submission/css/admin_dashboard.css
+++ b/submission/static/submission/css/admin_dashboard.css
@@ -107,3 +107,9 @@ tr.clickable-row:hover {
     align-items: center;
     justify-content: center;
 }
+.student-photo img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+}

--- a/submission/static/submission/css/teacher_dashboard.css
+++ b/submission/static/submission/css/teacher_dashboard.css
@@ -90,3 +90,9 @@ tr.clickable-row:hover {
     align-items: center;
     justify-content: center;
 }
+.student-photo img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
+}

--- a/submission/templates/submission/dashboard_student.html
+++ b/submission/templates/submission/dashboard_student.html
@@ -2,11 +2,30 @@
 {% verbatim %}
 <div class="student-ticket-list">
   <div v-for="stu in students" :key="stu.id" class="student-ticket" @click="openStudentModal(stu)">
-    <div class="student-photo"></div>
+    <div class="student-photo">
+        <img v-if="stu.photo" :src="stu.photo" alt="photo">
+    </div>
     <div class="fw-bold">{{ stu.full_name }}</div>
     <div>学籍番号: {{ stu.student_id }}</div>
     <div>曜日: {{ stu.experiment_day }}</div>
     <div>班: {{ stu.experiment_group }}</div>
+  </div>
+</div>
+<div v-if="showPhotoModal" class="modal" tabindex="-1" style="display:block; background:rgba(0,0,0,0.2)">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">顔写真撮影</h5>
+        <button type="button" class="btn-close" @click="closePhotoModal"></button>
+      </div>
+      <div class="modal-body text-center">
+        <video ref="video" autoplay style="width:100%"></video>
+        <canvas ref="canvas" style="display:none;"></canvas>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-primary" @click="capturePhoto">撮影</button>
+      </div>
+    </div>
   </div>
 </div>
 {% endverbatim %}
@@ -26,6 +45,9 @@
           </li>
         </ul>
         <div v-if="studentReports.length === 0">レポート提出なし</div>
+        <div class="text-end mt-2">
+            <button class="btn btn-secondary" @click="openPhotoModal">顔写真</button>
+        </div>
         {% endverbatim %}
       </div>
     </div>

--- a/submission/templates/submission/teacher_dashboard.html
+++ b/submission/templates/submission/teacher_dashboard.html
@@ -80,7 +80,9 @@
             <div class="student-ticket-list">
                 {% verbatim %}
                 <div v-for="stu in students" :key="stu.id" class="student-ticket" @click="openStudentModal(stu)">
-                    <div class="student-photo"></div>
+                    <div class="student-photo">
+                        <img v-if="stu.photo" :src="stu.photo" alt="photo">
+                    </div>
                     <div class="fw-bold">{{ stu.full_name }}</div>
                     <div>曜日: {{ stu.experiment_day }}</div>
                     <div>班: {{ stu.experiment_group }}</div>

--- a/submission/urls.py
+++ b/submission/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     path('api_student_reports/', views_admin.api_student_reports, name='api_student_reports'),
     path('admin_schedule_api/', views_admin.get_schedule_api, name='get_schedule_api'),
     path('admin_summary_api/', views_admin.get_summary_api, name='get_summary_api'),
+    path('upload_photo/<int:student_id>/', views_admin.upload_student_photo, name='upload_student_photo'),
     path('add_schedule_api/', views_admin.add_schedule_api, name='add_schedule_api'),
     path('update_schedule_api/<int:schedule_id>/', views_admin.update_schedule_api, name='update_schedule_api'),
     path('delete_schedule_api/<int:schedule_id>/', views_admin.delete_schedule_api, name='delete_schedule_api'),

--- a/submission/views_teacher.py
+++ b/submission/views_teacher.py
@@ -107,6 +107,7 @@ def teacher_students_api(request):
             'student_id': up.student_id,
             'experiment_day': up.experiment_day,
             'experiment_group': up.experiment_group,
+            'photo': up.photo.url if up.photo else '',
             'experiment_completion': completed,
         })
     return JsonResponse({'students': students})


### PR DESCRIPTION
## Summary
- add `photo` field to `UserProfile`
- create migration for photo field
- expose photo in admin and teacher APIs
- add endpoint `/upload_photo/<student_id>/` for saving captured images
- display student photos on teacher and admin dashboards
- add camera modal and capture logic in admin dashboard
- include styling for photo thumbnails

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684a92177ca4832ca4eba27df49494e3