### PR TITLE
Fix redirect for non-editing teacher

### DIFF
--- a/submission/views.py
+++ b/submission/views.py
@@ -55,6 +55,8 @@ def index_redirect(request):
         return redirect('admin_dashboard')
     elif role == "teacher":
         return redirect('teacher_dashboard')
+    elif role == "non-editing teacher":
+        return redirect('non_editing_teacher_dashboard')
     elif role == "student":
         return redirect('student_dashboard')
     else:


### PR DESCRIPTION
## Summary
- update `index_redirect` to handle `non-editing teacher`

## Testing
- `python manage.py test` *(fails: Could not import Django)*

------
https://chatgpt.com/codex/tasks/task_b_684bee09ddf4832b82a7e1766cc6388b