### PR TITLE
Improve non-editing teacher grading view

### DIFF
--- a/submission/templates/submission/final_grading_form.html
+++ b/submission/templates/submission/final_grading_form.html
@@ -18,6 +18,33 @@
   <div class="mb-3">
     <iframe src="{{ submission.file.url }}" style="width:100%; height:70vh;"></iframe>
   </div>
+  <div class="mb-3">
+    <h5>採点詳細</h5>
+    <table class="table">
+      <thead>
+        <tr><th colspan="2">予習レポート</th></tr>
+      </thead>
+      <tbody>
+        {% for item in pre_items %}
+        <tr>
+          <td>{{ item.label }}</td>
+          <td>{{ item.value }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+      <thead>
+        <tr><th colspan="2">本レポート</th></tr>
+      </thead>
+      <tbody>
+        {% for item in main_items %}
+        <tr>
+          <td>{{ item.label }}</td>
+          <td>{{ item.value }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
   <form method="post" class="mt-3">
     {% csrf_token %}
     <div class="mb-3">

--- a/submission/templates/submission/grading_form.html
+++ b/submission/templates/submission/grading_form.html
@@ -18,10 +18,12 @@
                 <span>提出日: {{ submission.submitted_at|date:"Y-m-d H:i" }}</span>
             </div>
             <div class="pdf-toolbar mb-2">
+                {% if request.user.userprofile.role != 'non-editing teacher' %}
                 <button class="btn btn-outline-secondary" :class="{active: tool==='pen'}"
                     @click="tool='pen'">ペン</button>
                 <button class="btn btn-outline-secondary" :class="{active: tool==='highlight'}"
                     @click="tool='highlight'">蛍光ペン</button>
+                {% endif %}
                 <button class="btn btn-outline-secondary" :class="{active: tool==='eraser'}"
                     @click="tool='eraser'">消しゴム</button>
                 <button class="btn btn-outline-secondary" :class="{active: tool==='stamp'}"
@@ -31,19 +33,23 @@
                     <option v-for="s in stamps" :key="s.id" :value="s.text">{{ s.text }}</option>
                     {% endverbatim %}
                 </select>
+                {% if request.user.userprofile.role != 'non-editing teacher' %}
                 <input v-if="tool==='pen'" type="range" min="1" max="10" v-model.number="penWidth" class="form-range d-inline-block ms-2" style="width:100px;">
                 <input v-if="tool==='highlight'" type="range" min="5" max="30" v-model.number="highlightWidth" class="form-range d-inline-block ms-2" style="width:100px;">
                 <button class="btn btn-outline-secondary ms-2" @click="undo(currentPage != null ? currentPage : 0)">戻る</button>
                 <button class="btn btn-outline-secondary ms-2" @click="redo(currentPage != null ? currentPage : 0)">進む</button>
+                {% endif %}
             </div>
             <div id="pdf-area" style="position:relative;width:100%;background:#eee;overflow-y:auto;max-height:80vh;">
                 <div id="pdf-pages">
                     <!-- 各ページcanvas＋手書きcanvasをVueで生成 -->
                     <div v-for="(page, idx) in pdfPages" :key="idx" style="position:relative;">
                         <canvas :ref="'pdfCanvas' + idx"></canvas>
-                        <canvas :ref="'drawCanvas' + idx" style="position:absolute;left:0;top:0;pointer-events:auto;"
+                        <canvas :ref="'drawCanvas' + idx" style="position:absolute;left:0;top:0;pointer-events:{% if request.user.userprofile.role == 'non-editing teacher' %}none{% else %}auto{% endif %};"
+                            {% if request.user.userprofile.role != 'non-editing teacher' %}
                             @mousedown="startDraw(idx, $event)" @mousemove="draw(idx, $event)" @mouseup="stopDraw(idx)"
-                            @mouseleave="stopDraw(idx)"></canvas>
+                            @mouseleave="stopDraw(idx)"
+                            {% endif %}></canvas>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- show scoring details on non-editing teacher final grading form
- hide annotation tools when role is non-editing teacher
- disable drawing for non-editing teacher
- compute pre and main scores in the final grading view

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_684bed5ee1b4832bacdef10be6633465