### PR TITLE
Improve non-editing teacher workflow

### DIFF
--- a/submission/templates/submission/final_grading_form.html
+++ b/submission/templates/submission/final_grading_form.html
@@ -5,6 +5,7 @@
 
 {% block extra_css %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="{% static 'submission/css/grading_form.css' %}">
 {% endblock %}
 
 {% block content %}
@@ -19,7 +20,7 @@
     <iframe src="{{ submission.file.url }}" style="width:100%; height:70vh;"></iframe>
   </div>
   <div class="mb-3">
-    <h5>採点詳細</h5>
+    <h5>採点エリア</h5>
     <table class="table">
       <thead>
         <tr><th colspan="2">予習レポート</th></tr>
@@ -28,7 +29,11 @@
         {% for item in pre_items %}
         <tr>
           <td>{{ item.label }}</td>
-          <td>{{ item.value }}</td>
+          <td>
+            <button class="btn btn-sm btn-outline-secondary" disabled>-</button>
+            <span class="mx-2">{{ item.value }}</span>
+            <button class="btn btn-sm btn-outline-secondary" disabled>+</button>
+          </td>
         </tr>
         {% endfor %}
       </tbody>
@@ -39,23 +44,26 @@
         {% for item in main_items %}
         <tr>
           <td>{{ item.label }}</td>
-          <td>{{ item.value }}</td>
+          <td>
+            <button class="btn btn-sm btn-outline-secondary" disabled>-</button>
+            <span class="mx-2">{{ item.value }}</span>
+            <button class="btn btn-sm btn-outline-secondary" disabled>+</button>
+          </td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
+    <div class="score-total">
+      合計：{{ total_score }}
+    </div>
+    <form method="post" class="mt-3">
+      {% csrf_token %}
+      <div class="mb-3">
+        <label class="form-label">最終評価 (0~100)</label>
+        <input type="number" name="final_value" min="0" max="100" step="0.1" class="form-control" value="{{ final_value }}">
+      </div>
+      <button type="submit" class="btn btn-success w-100">完了（保存）</button>
+    </form>
   </div>
-  <form method="post" class="mt-3">
-    {% csrf_token %}
-    <div class="mb-3">
-      <label class="form-label">合計得点</label>
-      <input type="text" class="form-control" value="{{ total_score }}" readonly>
-    </div>
-    <div class="mb-3">
-      <label class="form-label">最終評価 (0~100)</label>
-      <input type="number" name="final_value" min="0" max="100" step="0.1" class="form-control" value="{{ final_value }}">
-    </div>
-    <button type="submit" class="btn btn-primary">保存</button>
-  </form>
 </div>
 {% endblock %}

--- a/submission/templates/submission/graded_list.html
+++ b/submission/templates/submission/graded_list.html
@@ -23,7 +23,7 @@
                 <td>{{ item.experiment_number }}</td>
                 <td>{{ item.full_name }}</td>
                 <td class="filename-td">
-                    <a :href="'/submission/grading_form/' + item.id + '/'" @click.stop>
+                    <a :href="USER_ROLE === 'non-editing teacher' ? '/submission/final_grading_form/' + item.id + '/' : '/submission/grading_form/' + item.id + '/'" @click.stop>
                         {{ item.file ? item.file.split('/').pop().slice(0, 20) + (item.file.split('/').pop().length > 20 ?
                         '...' : '') : '' }}
                     </a>

--- a/submission/templates/submission/grading_list.html
+++ b/submission/templates/submission/grading_list.html
@@ -34,7 +34,7 @@
             <td>{{ row.experiment_number }}</td>
             <td>{{ row.full_name }}</td>
             <td class="filename-td">
-                <a :href="'/submission/grading_form/' + row.id + '/'" @click.stop>
+                <a :href="USER_ROLE === 'non-editing teacher' ? '/submission/final_grading_form/' + row.id + '/' : '/submission/grading_form/' + row.id + '/'" @click.stop>
                     {{ row.file ? row.file.split('/').pop().slice(0, 20) + (row.file.split('/').pop().length > 20 ?
                     '...' : '') : '' }}
                 </a>


### PR DESCRIPTION
## Summary
- adjust links in ungraded/graded lists so non-editing teachers open the final grading form
- restyle the final grading form score area to match the grading form

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_684bf7324334832b9dd1719b83fe8203