### PR TITLE
Add dark mode toggle

### DIFF
--- a/submission/static/submission/css/dark_mode.css
+++ b/submission/static/submission/css/dark_mode.css
@@ -1,0 +1,40 @@
+body.dark-mode {
+    background: #121212;
+    color: #e0e0e0;
+}
+body.dark-mode .ts-header {
+    background: #333;
+    color: #fff;
+}
+body.dark-mode .ts-header-title {
+    color: #fff;
+}
+body.dark-mode .burger-menu span {
+    background: #ccc;
+}
+body.dark-mode .menu-panel.glass {
+    background: rgba(30,30,30,0.95);
+    color: #e0e0e0;
+}
+body.dark-mode .menu-link {
+    color: #e0e0e0;
+}
+body.dark-mode .menu-link:hover:not(.disabled) {
+    background: #444;
+    color: #fff;
+}
+body.dark-mode .menu-overlay {
+    background: rgba(0,0,0,0.5);
+}
+body.dark-mode .ts-footer {
+    background: #222;
+    color: #ccc;
+}
+body.dark-mode .footer-link,
+body.dark-mode .footer-home {
+    color: #bbb;
+}
+body.dark-mode .footer-link:hover,
+body.dark-mode .footer-home:hover {
+    color: #fff;
+}

--- a/submission/static/submission/css/header.css
+++ b/submission/static/submission/css/header.css
@@ -51,6 +51,18 @@
     letter-spacing: 1.5px;
     color: #37294e;
 }
+.dark-toggle {
+    position: absolute;
+    right: 1.3rem;
+    top: 50%;
+    transform: translateY(-50%);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 1.2rem;
+    z-index: 2002;
+}
+.dark-toggle span { pointer-events: none; }
 .menu-overlay {
     position: fixed;
     top: 0; left: 0; width: 100vw; height: 100vh;

--- a/submission/static/submission/js/header.js
+++ b/submission/static/submission/js/header.js
@@ -1,12 +1,27 @@
 new Vue({
     el: '#vue-header-app',
     data: {
-      showMenu: false,
-      role: USER_ROLE || 'student',
-      userName: USER_NAME || 'USER'
+        showMenu: false,
+        role: USER_ROLE || 'student',
+        userName: USER_NAME || 'USER',
+        isDark: localStorage.getItem('dark-mode') === 'true'
     },
     methods: {
-      toggleMenu() { this.showMenu = !this.showMenu; },
-      closeMenu() { this.showMenu = false; },
+        toggleMenu() { this.showMenu = !this.showMenu; },
+        closeMenu() { this.showMenu = false; },
+        toggleDark() {
+            this.isDark = !this.isDark;
+            if (this.isDark) {
+                document.body.classList.add('dark-mode');
+            } else {
+                document.body.classList.remove('dark-mode');
+            }
+            localStorage.setItem('dark-mode', this.isDark);
+        }
+    },
+    mounted() {
+        if (this.isDark) {
+            document.body.classList.add('dark-mode');
+        }
     }
-  });
+});

--- a/submission/templates/base.html
+++ b/submission/templates/base.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{% static 'submission/css/fade.css' %}">
     <link rel="stylesheet" href="{% static 'submission/css/header.css' %}">
     <link rel="stylesheet" href="{% static 'submission/css/footer.css' %}">
+    <link rel="stylesheet" href="{% static 'submission/css/dark_mode.css' %}">
     {% block extra_css %}{% endblock %}
 </head>
 <body>

--- a/submission/templates/submission/header.html
+++ b/submission/templates/submission/header.html
@@ -5,6 +5,10 @@
     <span :class="{ open: showMenu }"></span>
   </button>
   <span class="ts-header-title">情報工学実験Ⅱ管理システム presented by TSlab</span>
+  <button class="dark-toggle" type="button" @click="toggleDark">
+    <span v-if="isDark">☀</span>
+    <span v-else>🌙</span>
+  </button>
   <transition name="fade">
     <div v-if="showMenu" class="menu-overlay" @click="closeMenu">
       <aside class="menu-panel glass" @click.stop>


### PR DESCRIPTION
## Summary
- add `dark_mode.css` for dark theme overrides
- link the new stylesheet in `base.html`
- add a dark mode toggle button in the header
- style the toggle and connect it in `header.js`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_b_684d4cc208bc832bb8dee36bc37d0143