### PR TITLE
Add dark mode toggle

### DIFF
--- a/submission/static/submission/css/dark_mode.css
+++ b/submission/static/submission/css/dark_mode.css
@@ -1,0 +1,10 @@
+body.dark-mode {
+    background: #121212;
+    color: #e0e0e0;
+}
+body.dark-mode a { color: #8ab4f8; }
+body.dark-mode a:hover { color: #a1cbff; }
+body.dark-mode img,
+body.dark-mode video {
+    filter: invert(1) hue-rotate(180deg);
+}

--- a/submission/static/submission/css/header.css
+++ b/submission/static/submission/css/header.css
@@ -121,6 +121,17 @@
     background: #ffe5eb !important;
     color: #a11a3a !important;
 }
+
+.dark-toggle {
+    position: absolute;
+    right: 1.3rem;
+    top: 50%;
+    transform: translateY(-50%);
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-size: 1.3rem;
+}
 @media (max-width: 600px) {
     .ts-header {
         min-height: 42px;
@@ -132,5 +143,8 @@
     }
     .ts-burger-menu {
         left: 0.5rem;
+    }
+    .dark-toggle {
+        right: 0.5rem;
     }
 }

--- a/submission/static/submission/js/header.js
+++ b/submission/static/submission/js/header.js
@@ -3,10 +3,27 @@ new Vue({
     data: {
       showMenu: false,
       role: USER_ROLE || 'student',
-      userName: USER_NAME || 'USER'
+      userName: USER_NAME || 'USER',
+      isDark: false
+    },
+    created() {
+      this.isDark = localStorage.getItem('ts-theme') === 'dark';
+      if (this.isDark) {
+        document.body.classList.add('dark-mode');
+      }
     },
     methods: {
       toggleMenu() { this.showMenu = !this.showMenu; },
       closeMenu() { this.showMenu = false; },
+      toggleTheme() {
+        this.isDark = !this.isDark;
+        if (this.isDark) {
+          document.body.classList.add('dark-mode');
+          localStorage.setItem('ts-theme', 'dark');
+        } else {
+          document.body.classList.remove('dark-mode');
+          localStorage.setItem('ts-theme', 'light');
+        }
+      }
     }
   });

--- a/submission/templates/base.html
+++ b/submission/templates/base.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="{% static 'submission/css/fade.css' %}">
     <link rel="stylesheet" href="{% static 'submission/css/header.css' %}">
     <link rel="stylesheet" href="{% static 'submission/css/footer.css' %}">
+    <link rel="stylesheet" href="{% static 'submission/css/dark_mode.css' %}">
     {% block extra_css %}{% endblock %}
 </head>
 <body>
@@ -18,6 +19,11 @@
     </div>
     <div id="footer-area">{% include 'submission/footer.html' %}</div>
     <script src="https://cdn.jsdelivr.net/npm/vue@2"></script>
+    <script>
+        if (localStorage.getItem('ts-theme') === 'dark') {
+            document.body.classList.add('dark-mode');
+        }
+    </script>
     <script>
         // Djangoのユーザー情報をグローバルJS変数にしてheader.jsで参照
         var USER_NAME = "{{ request.user.get_full_name|default:request.user.username }}";

--- a/submission/templates/submission/header.html
+++ b/submission/templates/submission/header.html
@@ -5,6 +5,10 @@
     <span :class="{ open: showMenu }"></span>
   </button>
   <span class="ts-header-title">情報工学実験Ⅱ管理システム presented by TSlab</span>
+  <button class="dark-toggle" type="button" @click="toggleTheme">
+    <span v-if="isDark">☀</span>
+    <span v-else>🌙</span>
+  </button>
   <transition name="fade">
     <div v-if="showMenu" class="menu-overlay" @click="closeMenu">
       <aside class="menu-panel glass" @click.stop>


### PR DESCRIPTION
## Summary
- implement a dark mode stylesheet
- add toggle button in header and style it
- remember theme across pages using localStorage
- load the dark theme automatically on page load

## Testing
- `python manage.py test` *(fails: Couldn't import Django)*

------
https://chatgpt.com/codex/tasks/task_e_684d5a95bb6c832c9afa92518f7fe31d