### PR TITLE
Modify grading links and add final grading side modal

### DIFF
--- a/submission/static/submission/js/final_grading_form.js
+++ b/submission/static/submission/js/final_grading_form.js
@@ -1,0 +1,9 @@
+new Vue({
+    el: '#final-grading-form',
+    data: {
+        showScore: false
+    },
+    methods: {
+        toggleScore() { this.showScore = !this.showScore; }
+    }
+});

--- a/submission/templates/submission/final_grading_form.html
+++ b/submission/templates/submission/final_grading_form.html
@@ -5,57 +5,72 @@
 
 {% block extra_css %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+<link rel="stylesheet" href="{% static 'submission/css/grading_form.css' %}">
 {% endblock %}
 
 {% block content %}
-<div class="container mt-4">
-  <h2 class="mb-3">最終評価</h2>
-  <div class="mb-3">
-    <span class="me-3">学生名: {{ submission.student.userprofile.full_name }}</span>
-    <span class="me-3">実験番号: {{ submission.experiment_number }}</span>
-    <span>提出日: {{ submission.submitted_at|date:"Y-m-d H:i" }}</span>
-  </div>
-  <div class="mb-3">
-    <iframe src="{{ submission.file.url }}" style="width:100%; height:70vh;"></iframe>
-  </div>
-  <div class="mb-3">
-    <h5>採点詳細</h5>
-    <table class="table">
-      <thead>
-        <tr><th colspan="2">予習レポート</th></tr>
-      </thead>
-      <tbody>
-        {% for item in pre_items %}
-        <tr>
-          <td>{{ item.label }}</td>
-          <td>{{ item.value }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-      <thead>
-        <tr><th colspan="2">本レポート</th></tr>
-      </thead>
-      <tbody>
-        {% for item in main_items %}
-        <tr>
-          <td>{{ item.label }}</td>
-          <td>{{ item.value }}</td>
-        </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
-  <form method="post" class="mt-3">
-    {% csrf_token %}
-    <div class="mb-3">
-      <label class="form-label">合計得点</label>
-      <input type="text" class="form-control" value="{{ total_score }}" readonly>
+<div id="final-grading-form" class="container-fluid" v-cloak>
+  <div class="row" style="position:relative;">
+    <div class="pdf-col" style="padding-top:40px;">
+      <div class="mb-3">
+        <h2 class="mb-3">最終評価</h2>
+        <div>
+          <span class="me-3">学生名: {{ submission.student.userprofile.full_name }}</span>
+          <span class="me-3">実験番号: {{ submission.experiment_number }}</span>
+          <span>提出日: {{ submission.submitted_at|date:"Y-m-d H:i" }}</span>
+        </div>
+      </div>
+      <div class="mb-3">
+        <iframe src="{{ submission.file.url }}" style="width:100%; height:70vh;"></iframe>
+      </div>
     </div>
-    <div class="mb-3">
-      <label class="form-label">最終評価 (0~100)</label>
-      <input type="number" name="final_value" min="0" max="100" step="0.1" class="form-control" value="{{ final_value }}">
+    <div style="position: fixed; right: 16px; top: 16px; z-index:10000;">
+      <button class="btn btn-primary score-toggle-btn" @click="toggleScore" :disabled="showScore">採点詳細</button>
     </div>
-    <button type="submit" class="btn btn-primary">保存</button>
-  </form>
+    <transition name="slide-right">
+      <div v-if="showScore" class="score-modal-float">
+        <h5>採点詳細</h5>
+        <table class="table">
+          <thead>
+            <tr><th colspan="2">予習レポート</th></tr>
+          </thead>
+          <tbody>
+            {% for item in pre_items %}
+            <tr>
+              <td>{{ item.label }}</td>
+              <td>{{ item.value }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+          <thead>
+            <tr><th colspan="2">本レポート</th></tr>
+          </thead>
+          <tbody>
+            {% for item in main_items %}
+            <tr>
+              <td>{{ item.label }}</td>
+              <td>{{ item.value }}</td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+        <form method="post" class="mt-3">
+          {% csrf_token %}
+          <div class="mb-3">
+            <label class="form-label">合計得点</label>
+            <input type="text" class="form-control" value="{{ total_score }}" readonly>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">最終評価 (0~100)</label>
+            <input type="number" name="final_value" min="0" max="100" step="0.1" class="form-control" value="{{ final_value }}">
+          </div>
+          <button type="submit" class="btn btn-primary w-100">保存</button>
+          <button type="button" class="btn btn-outline-secondary w-100 mt-2" @click="toggleScore">閉じる</button>
+        </form>
+      </div>
+    </transition>
+  </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/vue@2"></script>
+<script src="{% static 'submission/js/final_grading_form.js' %}"></script>
 {% endblock %}

--- a/submission/templates/submission/graded_list.html
+++ b/submission/templates/submission/graded_list.html
@@ -23,7 +23,7 @@
                 <td>{{ item.experiment_number }}</td>
                 <td>{{ item.full_name }}</td>
                 <td class="filename-td">
-                    <a :href="'/submission/grading_form/' + item.id + '/'" @click.stop>
+                    <a :href="(USER_ROLE === 'non-editing teacher' ? '/submission/final_grading_form/' : '/submission/grading_form/') + item.id + '/'" @click.stop>
                         {{ item.file ? item.file.split('/').pop().slice(0, 20) + (item.file.split('/').pop().length > 20 ?
                         '...' : '') : '' }}
                     </a>

--- a/submission/templates/submission/grading_list.html
+++ b/submission/templates/submission/grading_list.html
@@ -34,7 +34,7 @@
             <td>{{ row.experiment_number }}</td>
             <td>{{ row.full_name }}</td>
             <td class="filename-td">
-                <a :href="'/submission/grading_form/' + row.id + '/'" @click.stop>
+                <a :href="(USER_ROLE === 'non-editing teacher' ? '/submission/final_grading_form/' : '/submission/grading_form/') + row.id + '/'" @click.stop>
                     {{ row.file ? row.file.split('/').pop().slice(0, 20) + (row.file.split('/').pop().length > 20 ?
                     '...' : '') : '' }}
                 </a>


### PR DESCRIPTION
## Summary
- update links in grading lists so non-editing teachers open the final grading form
- show final grading details in a side modal
- add small Vue script for final grading page

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_684f97fc2bac832caef895fccde16318