### PR TITLE
Implement stamp deletion feature

### DIFF
--- a/submission/static/submission/js/stamps.js
+++ b/submission/static/submission/js/stamps.js
@@ -24,6 +24,23 @@ new Vue({
           alert('登録失敗');
         }
       });
+    },
+    deleteStamp(id) {
+      if (!confirm('本当に削除しますか？')) return;
+      fetch(`/submission/delete_stamp_api/${id}/`, {
+        method: 'POST',
+        headers: {
+          'X-CSRFToken': window.csrfToken
+        }
+      })
+      .then(res => res.json())
+      .then(data => {
+        if (data.status === 'success') {
+          this.stamps = this.stamps.filter(s => s.id !== id);
+        } else {
+          alert('削除失敗: ' + (data.message || ''));
+        }
+      });
     }
   }
 });

--- a/submission/templates/submission/stamps.html
+++ b/submission/templates/submission/stamps.html
@@ -16,7 +16,10 @@
   </div>
   <ul class="list-group" style="max-width:300px;">
     {% verbatim %}
-    <li class="list-group-item" v-for="s in stamps" :key="s.id">{{ s.text }}</li>
+    <li class="list-group-item d-flex justify-content-between align-items-center" v-for="s in stamps" :key="s.id">
+      <span>{{ s.text }}</span>
+      <button class="btn btn-sm btn-outline-danger" @click="deleteStamp(s.id)">削除</button>
+    </li>
     {% endverbatim %}
   </ul>
 </div>

--- a/submission/urls.py
+++ b/submission/urls.py
@@ -42,6 +42,7 @@ urlpatterns = [
     path('delete_schedule_api/<int:schedule_id>/', views_admin.delete_schedule_api, name='delete_schedule_api'),
     path('scoring_items/', views_admin.scoring_items, name='scoring_items'),  # admin only
     path('stamps/', views_admin.stamps_view, name='stamp_list'),
+    path('delete_stamp_api/<int:stamp_id>/', views_admin.delete_stamp_api, name='delete_stamp_api'),
     path('accept_submission/', views_admin.accept_submission, name='accept_submission'),
     
     # 学生系

--- a/submission/views_admin.py
+++ b/submission/views_admin.py
@@ -231,6 +231,20 @@ def stamps_view(request):
     })
 
 @csrf_exempt
+@role_required('admin')
+def delete_stamp_api(request, stamp_id):
+    if request.method == 'POST':
+        try:
+            stamp = Stamp.objects.get(id=stamp_id)
+            stamp.delete()
+            return JsonResponse({'status': 'success'})
+        except Stamp.DoesNotExist:
+            return JsonResponse({'status': 'error', 'message': 'Stampが見つかりません'}, status=404)
+        except Exception as e:
+            return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
+    return JsonResponse({'status': 'error', 'message': 'POSTでリクエストしてください'}, status=400)
+
+@csrf_exempt
 @require_POST
 @role_required('admin')
 def accept_submission(request):


### PR DESCRIPTION
## Summary
- add admin API endpoint to delete a stamp
- show delete button for each stamp in admin UI
- support deletion via Vue frontend
- expose new endpoint in `submission/urls.py`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6853b3ed7fe4832c8f4ffbed36c5cb57