### PR TITLE
Display all times in JST using 24‑hour format

### DIFF
--- a/submission/models.py
+++ b/submission/models.py
@@ -2,6 +2,7 @@ from django.db import models
 
 # Create your models here.
 from django.contrib.auth.models import User
+from django.utils import timezone
 
 class Submission(models.Model):
     student = models.ForeignKey(User, on_delete=models.CASCADE)  # 提出者（学生）
@@ -36,7 +37,8 @@ class Submission(models.Model):
     #student_id = models.CharField(max_length=10, blank=True)
 
     def __str__(self):
-        return f"{self.student.username} - {self.submitted_at.strftime('%Y-%m-%d %H:%M:%S')}"
+        local_time = timezone.localtime(self.submitted_at)
+        return f"{self.student.username} - {local_time.strftime('%Y-%m-%d %H:%M:%S')}"
 
 class UserProfile(models.Model):
     ROLE_CHOICES = [

--- a/submission/views.py
+++ b/submission/views.py
@@ -12,6 +12,7 @@ from django.core.serializers import serialize
 from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.decorators import user_passes_test
 from django.contrib.auth.decorators import login_required
+from django.utils import timezone
 
 from .models import UserProfile, Submission, Schedule
 from .forms import SubmissionForm, SignUpForm
@@ -81,7 +82,7 @@ def api_user_profile(request):
                 "file": s.file.url if s.file else "",
                 "experiment_number": s.experiment_number,
                 "report_type": '予レポート' if s.report_type == 'prep' else '本レポート',
-                "submitted_at": s.submitted_at.strftime('%Y-%m-%d %H:%M'),
+                "submitted_at": timezone.localtime(s.submitted_at).strftime('%Y-%m-%d %H:%M'),
             }
             for s in submissions
         ]

--- a/submission/views_admin.py
+++ b/submission/views_admin.py
@@ -19,6 +19,7 @@ from django.http import JsonResponse, HttpResponse
 from django.views.decorators.http import require_POST
 from collections import Counter
 from django.contrib.auth.models import User, Permission
+from django.utils import timezone
 
 @role_required('admin')
 def admin_dashboard(request):
@@ -269,7 +270,7 @@ def api_student_reports(request):
             "file": items.file.url if items.file else "",
             "experiment_number": items.experiment_number,
             "report_type": '予' if items.report_type == 'prep' else '本' ,
-            "submitted_at": items.submitted_at.strftime('%Y-%m-%d %H:%M'),
+            "submitted_at": timezone.localtime(items.submitted_at).strftime('%Y-%m-%d %H:%M'),
         })
     return JsonResponse({'reports': data,'full_name': full_name})
 
@@ -285,7 +286,10 @@ def user_list_view(request):
             profile = user.userprofile
             role = profile.role
             group = f"{profile.experiment_day}-{str(profile.experiment_group).zfill(2)}"
-            last_login = user.last_login.strftime("%Y-%m-%d %H:%M") if user.last_login else "未ログイン"
+            last_login = (
+                timezone.localtime(user.last_login).strftime("%Y-%m-%d %H:%M")
+                if user.last_login else "未ログイン"
+            )
             user_data.append({
                 'id': user.id,
                 'name': profile.full_name,

--- a/submission/views_student.py
+++ b/submission/views_student.py
@@ -5,8 +5,9 @@ import json
 from submission.decorators import role_required
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_POST
-from django.http import JsonResponse 
+from django.http import JsonResponse
 import datetime
+from django.utils import timezone
 from django.middleware.csrf import get_token
 import os
 
@@ -30,7 +31,7 @@ def student_dashboard(request):
             "experiment_number": sub.experiment_number,  # 実験番号
             "file_name": sub.file.name.split('/')[-1] if sub.file else "",
             "file_url": sub.file.url if sub.file else "",
-            "submitted_at": sub.submitted_at.strftime('%Y-%m-%d %H:%M'), #提出日
+            "submitted_at": timezone.localtime(sub.submitted_at).strftime('%Y-%m-%d %H:%M'), #提出日
             "status": status,
             "graded_score": (
                 sum(item.get("value", 0) * item.get("weight", 1) for item in sub.score_details)


### PR DESCRIPTION
## Summary
- convert datetime displays to JST using `timezone.localtime`
- show times in 24‑hour format consistently

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_6853c5cfee28832c8379234b0f8b4a2c