### PR TITLE
Improve request security

### DIFF
--- a/attendance/views.py
+++ b/attendance/views.py
@@ -9,7 +9,6 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.utils import timezone
 from django.views.decorators.http import require_POST
-from django.views.decorators.csrf import csrf_exempt
 
 from .models import AttendanceRecord
 from submission.models import UserProfile, Submission, ScoringItem
@@ -132,7 +131,6 @@ def get_user_info(request, student_id):
         return JsonResponse({'status': 'error', 'message': 'not found'}, status=404)
 
 
-@csrf_exempt
 @login_required
 @require_POST
 def register_nfc(request):

--- a/submission/forms.py
+++ b/submission/forms.py
@@ -11,7 +11,15 @@ from .models import UserProfile
 class SubmissionForm(forms.ModelForm):
     class Meta:
         model = Submission
-        fields = ['report_type', 'experiment_number', 'file'] 
+        fields = ['report_type', 'experiment_number', 'file']
+
+    def clean_file(self):
+        uploaded = self.cleaned_data.get('file')
+        if uploaded:
+            content_type = uploaded.content_type
+            if content_type != 'application/pdf' or not uploaded.name.lower().endswith('.pdf'):
+                raise ValidationError('PDFファイルのみアップロードできます。')
+        return uploaded
 
 # サインアップフォーム
 class SignUpForm(forms.ModelForm):

--- a/submission/views.py
+++ b/submission/views.py
@@ -2,23 +2,21 @@ from django.shortcuts import render
 
 # Create your views here.
 import json
-from django.http import HttpResponse
 from django.contrib import messages
 from django.http import JsonResponse
 from django.contrib.auth import login
 from django.shortcuts import redirect
 from django.contrib.auth.models import User
 from django.core.serializers import serialize
-from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.decorators import user_passes_test
 from django.contrib.auth.decorators import login_required
 from django.utils import timezone
+from django.views.decorators.http import require_POST
 
 from .models import UserProfile, Submission, Schedule
 from .forms import SubmissionForm, SignUpForm
 from submission.decorators import role_required
 from django.http import HttpResponse
-from django.shortcuts import render, redirect
 
 def signup_view(request):
     if request.method == 'POST':
@@ -104,20 +102,18 @@ def api_user_profile(request):
     return JsonResponse(result)
 
 @login_required
-@csrf_exempt
+@require_POST
 def api_change_password(request):
-    if request.method == "POST":
-        import json
-        data = json.loads(request.body)
-        password = data.get("password")
-        if password and len(password) >= 6:
-            user = request.user
-            user.set_password(password)
-            user.save()
-            return JsonResponse({"status": "ok"})
-        else:
-            return JsonResponse({"status": "ng", "message": "パスワードは6文字以上です"})
-    return JsonResponse({"status": "ng", "message": "POSTのみ"})
+    import json
+    data = json.loads(request.body)
+    password = data.get("password")
+    if password and len(password) >= 6:
+        user = request.user
+        user.set_password(password)
+        user.save()
+        return JsonResponse({"status": "ok"})
+    else:
+        return JsonResponse({"status": "ng", "message": "パスワードは6文字以上です"})
 
 @login_required
 def user_profile_view(request):

--- a/submission/views_admin.py
+++ b/submission/views_admin.py
@@ -7,7 +7,6 @@ from submission.models import (
     ScoringItem,
     ExperimentCompletion,
 )
-from django.views.decorators.csrf import csrf_exempt
 from django.core.files.storage import default_storage
 import json
 import csv
@@ -136,7 +135,6 @@ def get_schedule_api(request):
     ]
     return JsonResponse({'schedule_json': schedule})
 
-@csrf_exempt
 @role_required('admin')
 def add_schedule_api(request):
     if request.method == 'POST':
@@ -153,7 +151,6 @@ def add_schedule_api(request):
             return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
     return JsonResponse({'status': 'error', 'message': 'POSTでリクエストしてください'}, status=400)
 
-@csrf_exempt
 @role_required('admin')
 def update_schedule_api(request, schedule_id):
     if request.method == 'POST':
@@ -173,7 +170,6 @@ def update_schedule_api(request, schedule_id):
             return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
     return JsonResponse({'status': 'error', 'message': 'POSTでリクエストしてください'}, status=400)
 
-@csrf_exempt
 @role_required('admin')
 def delete_schedule_api(request, schedule_id):
     if request.method == 'POST':
@@ -231,7 +227,6 @@ def stamps_view(request):
         'stamps': json.dumps(stamps, ensure_ascii=False)
     })
 
-@csrf_exempt
 @role_required('admin')
 def delete_stamp_api(request, stamp_id):
     if request.method == 'POST':
@@ -245,7 +240,6 @@ def delete_stamp_api(request, stamp_id):
             return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
     return JsonResponse({'status': 'error', 'message': 'POSTでリクエストしてください'}, status=400)
 
-@csrf_exempt
 @require_POST
 @role_required('admin')
 def accept_submission(request):
@@ -311,7 +305,6 @@ def user_list_view(request):
     return render(request, 'submission/user_list.html', context)
 
 
-@csrf_exempt
 @role_required('admin')
 def update_user_role(request, user_id):
     if request.method == 'POST':
@@ -333,7 +326,6 @@ def update_user_role(request, user_id):
             return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
 
 
-@csrf_exempt
 @role_required('admin')
 def update_group_view(request, user_id):
     if request.method == 'POST':
@@ -348,7 +340,6 @@ def update_group_view(request, user_id):
         except Exception as e:
             return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
 
-@csrf_exempt
 @role_required('admin')
 def update_attendance_permission(request, user_id):
     if request.method == 'POST':
@@ -365,7 +356,6 @@ def update_attendance_permission(request, user_id):
         except Exception as e:
             return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
         
-@csrf_exempt
 @role_required('admin')
 def delete_user_view(request, user_id):
     if request.method == 'POST':
@@ -376,7 +366,6 @@ def delete_user_view(request, user_id):
         except User.DoesNotExist:
             return JsonResponse({'status': 'error', 'message': 'User not found'}, status=404)
 
-@csrf_exempt
 @role_required('admin')
 def create_user_view(request):
     if request.method == 'POST':
@@ -406,7 +395,6 @@ def create_user_view(request):
             return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
 
 
-@csrf_exempt
 @role_required('admin')
 def bulk_create_users(request):
     """Create multiple users from uploaded CSV file.
@@ -454,7 +442,6 @@ def bulk_create_users(request):
         return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
 
 
-@csrf_exempt
 @role_required('admin')
 def upload_student_photo(request, student_id):
     """Receive uploaded photo and save to UserProfile"""

--- a/submission/views_student.py
+++ b/submission/views_student.py
@@ -1,6 +1,5 @@
 from django.shortcuts import render
 from submission.models import UserProfile, Submission, Schedule
-from django.views.decorators.csrf import csrf_exempt
 import json
 from submission.decorators import role_required
 from django.contrib.auth.decorators import login_required
@@ -11,7 +10,6 @@ from django.utils import timezone
 from django.middleware.csrf import get_token
 import os
 
-@csrf_exempt
 @role_required('student')
 def student_dashboard(request):
     # ユーザ自身の提出物一覧を抽出

--- a/submission/views_teacher.py
+++ b/submission/views_teacher.py
@@ -6,7 +6,6 @@ from .models import Submission, UserProfile, ExperimentCompletion
 from decimal import Decimal
 from django.db.models import Q
 from django.contrib.auth.models import User
-from django.views.decorators.csrf import csrf_exempt
 
 @login_required
 def teacher_dashboard(request):


### PR DESCRIPTION
## Summary
- secure login password change endpoint using CSRF and POST requirement
- enforce PDF uploads for reports
- remove unnecessary csrf exemptions from views

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_6853c97aae60832c85ccf5255553572b