### PR TITLE
Update footer behavior and layout

### DIFF
--- a/submission/static/submission/css/footer.css
+++ b/submission/static/submission/css/footer.css
@@ -87,15 +87,26 @@ body {
 }
 
 .f-log{
-    margin: 0.2em auto 0 auto;
+    margin-right: 6px;
     height: 40px;
-    float: left;
+}
+
+.footer-left {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    padding: 0 10px;
+    display: flex;
+    align-items: center;
 }
 
 .copylight{
-    grid-area: copylight;
+    position: fixed;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
     font-size: 12px;
-    width: 100%;
     text-align: center;
     line-height: 25px;
+    width: max-content;
 }

--- a/submission/static/submission/css/header.css
+++ b/submission/static/submission/css/header.css
@@ -11,11 +11,12 @@
     z-index: 1100;
 }
 .subtitle {
-    display: block;
+    display: inline-block;
+    vertical-align: sub;
     font-size: 70%;
     margin-left: 4px;
     color: #666;
-  }
+}
 .ts-burger-menu {
     position: absolute;
     left: 1.3rem;

--- a/submission/templates/submission/footer.html
+++ b/submission/templates/submission/footer.html
@@ -1,16 +1,18 @@
 <footer class="ts-footer">
     <div class="footer-content">
         {% load static %}
-        <div ><img src="{% static 'submission/main-logo_small.png' %}" alt="ロゴ" class="f-log">高橋研究室</div>
+        <div class="footer-left"><img src="{% static 'submission/main-logo_small.png' %}" alt="ロゴ" class="f-log">高橋研究室</div>
+        {% if request.user.is_authenticated %}
         <div class="footer-login">
-            あなたは <span class="footer-user">{{ request.user.username }} {{ request.user.get_full_name }}</span> としてログインしています 
+            あなたは <span class="footer-user">{{ request.user.username }} {{ request.user.get_full_name }}</span> としてログインしています
             (<form method="post" action="{% url 'logout' %}" style="display:inline;">
                 {% csrf_token %}
                 <button type="submit" class="footer-logout" style="background:none;border:none;padding:0;">ログアウト</button>
             </form>)
         </div>
+        {% endif %}
         <!-- <a href="{% url 'index_redirect' %}" class="footer-home">Home</a> -->
         <div class="copylight" data-v-23c3547f=""> Copyright ©︎2025 Talahashi Lab.,CST, NU. All Rights Reserved. </div>
     </div>
-    
+
 </footer>

--- a/submission/templates/submission/header.html
+++ b/submission/templates/submission/header.html
@@ -4,8 +4,7 @@
     <span :class="{ open: showMenu }"></span>
     <span :class="{ open: showMenu }"></span>
   </button>
-  <span class="ts-header-title">情報工学実験Ⅱ管理システム</span>
-  <span class="subtitle">presented by TSlab</span>
+  <span class="ts-header-title">情報工学実験Ⅱ管理システム<sub class="subtitle">presented by TSlab</sub></span>
   <button class="dark-toggle" type="button" @click="toggleDark">
     <span v-if="isDark">☀</span>
     <span v-else>🌙</span>


### PR DESCRIPTION
## Summary
- hide login banner unless user is authenticated
- position lab logo on bottom left
- center copyright text at bottom
- display subtitle as subscript under main title

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6854d0c26108832cb7f229ed4487d42a