### PR TITLE
Fix overlapping footer items

### DIFF
--- a/submission/static/submission/css/footer.css
+++ b/submission/static/submission/css/footer.css
@@ -30,6 +30,10 @@ body {
     max-width: 1600px;
     margin: 0 auto;
     text-align: center;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
 }
 
 .footer-link {
@@ -82,7 +86,17 @@ body {
 
 /* レスポンシブ（スマホ） */
 @media (max-width: 600px) {
-    .footer-content { font-size: 0.93em; }
+    .footer-content {
+        font-size: 0.93em;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.5em;
+    }
+    .footer-left,
+    .footer-login,
+    .copylight {
+        margin-bottom: 0.3em;
+    }
     .footer-home { font-size: 0.93em; }
 }
 
@@ -92,19 +106,12 @@ body {
 }
 
 .footer-left {
-    position: fixed;
-    bottom: 0;
-    left: 0;
     padding: 0 10px;
     display: flex;
     align-items: center;
 }
 
 .copylight{
-    position: fixed;
-    bottom: 0;
-    left: 50%;
-    transform: translateX(-50%);
     font-size: 12px;
     text-align: center;
     line-height: 25px;


### PR DESCRIPTION
## Summary
- make footer layout responsive
- stack footer items when the screen width is small

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6854d74fa09c832c9261b45cac42b8d0