### PR TITLE
Add unified user edit modal on user list

### DIFF
--- a/submission/static/submission/js/user_table.js
+++ b/submission/static/submission/js/user_table.js
@@ -3,14 +3,13 @@ new Vue({
     data: {
         users: USERS_DATA.map(user => ({
             ...user,
-            editingRole: false,
-            editingGroup: false,
             can_view_attendance: user.can_view_attendance
         })),
         groupOptions: [].concat(...['火', '木'].map(day =>
             Array.from({ length: 20 }, (_, i) => day + '-' + ('0' + (i + 1)).slice(-2))
         )),
         showModal: false,
+        showEditModal: false,
         filters: { role: '', group: '' },
         sortField: '',
         sortAsc: true,
@@ -22,6 +21,15 @@ new Vue({
             student_id: '',
             experiment_day: '火',
             experiment_group: '01'
+        },
+        editUser: {
+            id: null,
+            full_name: '',
+            email: '',
+            student_id: '',
+            experiment_day: '火',
+            experiment_group: '01',
+            role: 'student'
         }
     },
     computed: {
@@ -48,63 +56,18 @@ new Vue({
                 this.sortAsc = true;
             }
         },
-        enableEdit(user, field) {
-            if (field === 'role') {
-                user.editingRole = true;
-                this.$nextTick(() => {
-                    $(`#roles-${user.id}`).select2().val(user.role).trigger('change');
-                });
-            }
-            if (field === 'group') {
-                user.editingGroup = true;
-                this.$nextTick(() => {
-                    $(`#groups-${user.id}`).select2().val(user.group).trigger('change');
-                });
-            }
-        },
-        saveRole(user) {
-            const role = $(`#roles-${user.id}`).val();
-            user.editingRole = false;
-            $(`#roles-${user.id}`).select2('destroy');
-            fetch(`/users/update_role/${user.id}/`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': CSRF_TOKEN
-                },
-                body: JSON.stringify({ role })
-            }).then(res => {
-                if (res.ok) {
-                    user.role = role;
-                }
-            });
-        },
-        saveGroup(user) {
-            const group = $(`#groups-${user.id}`).val();
-            const [day, grp] = group.split('-');
-            fetch(`/users/update_group/${user.id}/`, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRFToken': CSRF_TOKEN
-                },
-                body: JSON.stringify({ experiment_day: day, experiment_group: grp })
-            }).then(res => {
-                if (res.ok) {
-                    user.group = group;
-                    user.editingGroup = false;
-                }
-            });
-        },
-        cancelEdit(user, field) {
-            if (field === 'role') {
-                user.editingRole = false;
-                $(`#roles-${user.id}`).select2('destroy');
-            }
-            if (field === 'group') {
-                user.editingGroup = false;
-                $(`#groups-${user.id}`).select2('destroy');
-            }
+        openEditModal(user) {
+            const [experiment_day, experiment_group] = (user.group || '火-01').split('-');
+            this.editUser = {
+                id: user.id,
+                full_name: user.name,
+                email: user.email,
+                student_id: user.student_id,
+                experiment_day,
+                experiment_group,
+                role: user.role
+            };
+            this.showEditModal = true;
         },
         toggleAttendance(user) {
             fetch(`/users/update_permission/${user.id}/`, {
@@ -139,6 +102,49 @@ new Vue({
             .catch(err => {
                 console.error(err);
                 alert('通信エラーが発生しました');
+            });
+        },
+        updateUser() {
+            if (!this.editUser.id) return;
+
+            fetch(`/users/update/${this.editUser.id}/`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRFToken': CSRF_TOKEN,
+                },
+                body: JSON.stringify({
+                    full_name: this.editUser.full_name,
+                    email: this.editUser.email,
+                    student_id: this.editUser.student_id,
+                    experiment_day: this.editUser.experiment_day,
+                    experiment_group: this.editUser.experiment_group,
+                    role: this.editUser.role,
+                }),
+            })
+            .then(res => res.json())
+            .then(data => {
+                if (data.status === 'success') {
+                    const idx = this.users.findIndex(u => u.id === this.editUser.id);
+                    if (idx !== -1) {
+                        const updatedGroup = `${this.editUser.experiment_day}-${this.editUser.experiment_group}`;
+                        this.users.splice(idx, 1, {
+                            ...this.users[idx],
+                            name: this.editUser.full_name,
+                            email: this.editUser.email,
+                            student_id: this.editUser.student_id,
+                            group: updatedGroup,
+                            role: this.editUser.role,
+                        });
+                    }
+                    this.showEditModal = false;
+                    alert('ユーザー情報を更新しました');
+                } else {
+                    alert('更新に失敗しました: ' + data.message);
+                }
+            })
+            .catch(err => {
+                console.error('通信エラー', err);
             });
         },
         createUser() {

--- a/submission/templates/submission/user_list.html
+++ b/submission/templates/submission/user_list.html
@@ -4,7 +4,6 @@
 {% block title %}ユーザ一覧{% endblock %}
 
 {% block extra_css %}
-<link href="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" rel="stylesheet" />
 <link rel="stylesheet" href="{% static 'submission/css/user_table.css' %}">
 {% endblock %}
 
@@ -65,6 +64,57 @@
     </div>
     {% endverbatim %}
 
+    <!-- ユーザー編集モーダル -->
+    {% verbatim %}
+    <div v-if="showEditModal" class="ts-modal-overlay">
+        <div class="ts-modal">
+            <h3>ユーザ情報を編集</h3>
+            <form @submit.prevent="updateUser">
+                <div class="ts-form-group">
+                    <label>名前</label>
+                    <input type="text" v-model="editUser.full_name" required>
+                </div>
+                <div class="ts-form-group">
+                    <label>メールアドレス</label>
+                    <input type="email" v-model="editUser.email" required>
+                </div>
+                <div class="ts-form-group">
+                    <label>学籍番号</label>
+                    <input type="text" v-model="editUser.student_id" maxlength="4" required>
+                </div>
+                <div class="ts-form-group">
+                    <label>実験曜日</label>
+                    <select v-model="editUser.experiment_day">
+                        <option value="火">火</option>
+                        <option value="木">木</option>
+                    </select>
+                </div>
+                <div class="ts-form-group">
+                    <label>実験班</label>
+                    <select v-model="editUser.experiment_group">
+                        <option v-for="n in 20" :key="n" :value="('0' + n).slice(-2)">
+                            {{ ('0' + n).slice(-2) }}
+                        </option>
+                    </select>
+                </div>
+                <div class="ts-form-group">
+                    <label>ロール</label>
+                    <select v-model="editUser.role">
+                        <option value="student">student</option>
+                        <option value="teacher">teacher</option>
+                        <option value="non-editing teacher">non-editing teacher</option>
+                        <option value="admin">admin</option>
+                    </select>
+                </div>
+                <div class="ts-modal-actions mt-3">
+                    <button type="submit" class="ts-create-btn">登録</button>
+                    <button type="button" class="ts-cancel-btn" @click="showEditModal = false">キャンセル</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    {% endverbatim %}
+
     <!-- ユーザ一覧テーブル -->
     <div class="table-responsive">
         <table class="ts-table">
@@ -103,42 +153,14 @@
                     <td>{{ user.name }}</td>
                     <td>{{ user.email }}</td>
                     <td>{{ user.student_id }}</td>
-                    <!-- ロール編集 -->
-                    <td>
-                        <span v-if="!user.editingRole">
-                            {{ user.role }}
-                            <button class="ts-edit-btn" @click="enableEdit(user, 'role')">✏️</button>
-                        </span>
-                        <span v-else>
-                            <select :id="'roles-' + user.id" style="width: 120px;">
-                                <option value="student">student</option>
-                                <option value="teacher">teacher</option>
-                                <option value="non-editing teacher">non-editing teacher</option>
-                                <option value="admin">admin</option>
-                            </select>
-                            <button class="ts-save-btn" @click="saveRole(user)">💾</button>
-                            <button class="ts-cancel-edit-btn" @click="cancelEdit(user, 'role')">✕</button>
-                        </span>
-                    </td>
-                    <!-- グループ編集 -->
-                    <td>
-                        <span v-if="!user.editingGroup">
-                            {{ user.group }}
-                            <button class="ts-edit-btn" @click="enableEdit(user, 'group')">✏️</button>
-                        </span>
-                        <span v-else>
-                            <select :id="'groups-' + user.id" style="width: 100px;">
-                                <option v-for="option in groupOptions" :value="option" v-text="option"></option>
-                            </select>
-                            <button class="ts-save-btn" @click="saveGroup(user)">💾</button>
-                            <button class="ts-cancel-edit-btn" @click="cancelEdit(user, 'group')">✕</button>
-                        </span>
-                    </td>
+                    <td>{{ user.role }}</td>
+                    <td>{{ user.group }}</td>
                     <td>
                         <input type="checkbox" v-model="user.can_view_attendance" @change="toggleAttendance(user)">
                     </td>
                     <td>{{ user.last_login }}</td>
                     <td>
+                        <button class="ts-edit-btn" @click="openEditModal(user)">✏️</button>
                         <button class="ts-delete-btn" @click="deleteUser(user)">🗑️</button>
                     </td>
                 </tr>
@@ -151,9 +173,7 @@
     var USERS_DATA = {{ users_json|safe }};
     var CSRF_TOKEN = '{{ csrf_token }}';
 </script>
-<!-- Vue, jQuery, Select2, 自作JSの順 -->
+<!-- Vueと自作JSの読み込み -->
 <script src="https://cdn.jsdelivr.net/npm/vue@2"></script>
-<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.min.js"></script>
 <script src="{% static 'submission/js/user_table.js' %}"></script>
 {% endblock %}

--- a/submission/urls.py
+++ b/submission/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path('final_score_list/download_accepted/', views_admin.download_accepted_reports, name='download_accepted_reports'),
     path('update_role/<int:user_id>/', views_admin.update_user_role, name='update_role'),
     path('update_group/<int:user_id>/', views_admin.update_group_view, name='update_group'),
+    path('update/<int:user_id>/', views_admin.update_user_view, name='update_user'),
     path('update_permission/<int:user_id>/', views_admin.update_attendance_permission, name='update_attendance_permission'),
     path('delete/<int:user_id>/', views_admin.delete_user_view, name='delete_user'),
     path('create/', views_admin.create_user_view, name='create_user'),

--- a/submission/views_admin.py
+++ b/submission/views_admin.py
@@ -396,6 +396,49 @@ def create_user_view(request):
 
 
 @role_required('admin')
+def update_user_view(request, user_id):
+    if request.method != 'POST':
+        return JsonResponse({'status': 'error', 'message': 'POST required'}, status=400)
+
+    try:
+        data = json.loads(request.body)
+
+        user = User.objects.get(id=user_id)
+        profile = user.userprofile
+
+        new_email = data.get('email', '').strip()
+        if not new_email:
+            return JsonResponse({'status': 'error', 'message': 'メールアドレスは必須です。'}, status=400)
+
+        # 他ユーザとの重複チェック
+        if User.objects.filter(username=new_email).exclude(id=user_id).exists():
+            return JsonResponse({'status': 'error', 'message': 'このメールアドレスは既に使用されています。'}, status=400)
+
+        new_role = data.get('role', profile.role)
+
+        user.username = new_email
+        user.email = new_email
+        user.is_superuser = new_role == 'admin'
+        user.is_staff = new_role in ['teacher', 'admin']
+
+        profile.email = new_email
+        profile.full_name = data.get('full_name', profile.full_name)
+        profile.student_id = data.get('student_id', profile.student_id)
+        profile.experiment_day = data.get('experiment_day', profile.experiment_day)
+        profile.experiment_group = data.get('experiment_group', profile.experiment_group)
+        profile.role = new_role
+
+        profile.save()
+        user.save()
+
+        return JsonResponse({'status': 'success'})
+    except User.DoesNotExist:
+        return JsonResponse({'status': 'error', 'message': 'User not found'}, status=404)
+    except Exception as e:
+        return JsonResponse({'status': 'error', 'message': str(e)}, status=400)
+
+
+@role_required('admin')
 def bulk_create_users(request):
     """Create multiple users from uploaded CSV file.
 


### PR DESCRIPTION
## Summary
- add an edit modal in the user list to update name, email, student ID, role, and group together
- update Vue logic to populate and submit edits to a new backend endpoint and refresh the list inline
- add a server-side user update route with validation for email uniqueness and role permissions

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692fae6b8898832bb03c600ef8e6cfc2)